### PR TITLE
Update Installation Instructions to use v0.3.2

### DIFF
--- a/docs/nargo/0_nargo_installation.md
+++ b/docs/nargo/0_nargo_installation.md
@@ -12,7 +12,8 @@ keywords: [Nargo, command line tool, Noir programs, installation guide, how to u
 `nargo` is a command line tool for interacting with Noir programs (e.g. compiling, proving,
 verifying and more).
 
-Alternatively, the interactions can also be performed in [TypeScript](../getting_started/typescript.md).
+Alternatively, the interactions can also be performed in
+[TypeScript](../getting_started/typescript.md).
 
 ## Installation
 
@@ -25,6 +26,9 @@ Optionally you can also install [Noir VS Code extension] for syntax highlighting
 
 ### Option 1: Binaries
 
+See [GitHub Releases](https://github.com/noir-lang/noir/releases) for the latest and previous
+platform specific binaries.
+
 #### Step 1
 
 Paste and run the following in the terminal to extract and install the binary:
@@ -36,7 +40,7 @@ Paste and run the following in the terminal to extract and install the binary:
 
 ```bash
 mkdir -p $HOME/.nargo/bin && \
-curl -o $HOME/.nargo/bin/nargo-aarch64-apple-darwin.tar.gz -L https://github.com/noir-lang/noir/releases/download/nightly/nargo-aarch64-apple-darwin.tar.gz && \
+curl -o $HOME/.nargo/bin/nargo-aarch64-apple-darwin.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-aarch64-apple-darwin.tar.gz && \
 tar -xvf $HOME/.nargo/bin/nargo-aarch64-apple-darwin.tar.gz -C $HOME/.nargo/bin/ && \
 echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.zshrc && \
 source ~/.zshrc
@@ -46,7 +50,7 @@ source ~/.zshrc
 
 ```bash
 mkdir -p $HOME/.nargo/bin && \
-curl -o $HOME/.nargo/bin/nargo-x86_64-apple-darwin.tar.gz -L https://github.com/noir-lang/noir/releases/download/nightly/nargo-x86_64-apple-darwin.tar.gz && \
+curl -o $HOME/.nargo/bin/nargo-x86_64-apple-darwin.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-x86_64-apple-darwin.tar.gz && \
 tar -xvf $HOME/.nargo/bin/nargo-x86_64-apple-darwin.tar.gz -C $HOME/.nargo/bin/ && \
 echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.zshrc && \
 source ~/.zshrc
@@ -58,7 +62,7 @@ Open PowerShell as Administrator and run:
 
 ```sh
 mkdir -f -p "$env:USERPROFILE\.nargo\bin\"; `
-Invoke-RestMethod -Method Get -Uri https://github.com/noir-lang/noir/releases/download/nightly/nargo-x86_64-pc-windows-msvc.zip -Outfile "$env:USERPROFILE\.nargo\bin\nargo-x86_64-pc-windows-msvc.zip"; `
+Invoke-RestMethod -Method Get -Uri https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-x86_64-pc-windows-msvc.zip -Outfile "$env:USERPROFILE\.nargo\bin\nargo-x86_64-pc-windows-msvc.zip"; `
 Expand-Archive -Path "$env:USERPROFILE\.nargo\bin\nargo-x86_64-pc-windows-msvc.zip" -DestinationPath "$env:USERPROFILE\.nargo\bin\"; `
 $Reg = "Registry::HKLM\System\CurrentControlSet\Control\Session Manager\Environment"; `
 $OldPath = (Get-ItemProperty -Path "$Reg" -Name PATH).Path; `
@@ -69,12 +73,9 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 
 ##### Linux (Bash)
 
-See [GitHub Releases](https://github.com/noir-lang/noir/releases/tag/nightly) for additional
-platform specific binaries.
-
 ```bash
 mkdir -p $HOME/.nargo/bin && \
-curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github.com/noir-lang/noir/releases/download/nightly/nargo-x86_64-unknown-linux-gnu.tar.gz && \
+curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-x86_64-unknown-linux-gnu.tar.gz && \
 tar -xvf $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.nargo/bin/ && \
 echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
 source ~/.bashrc
@@ -122,11 +123,15 @@ Commands:
    git clone git@github.com:noir-lang/noir.git
    ```
 
-3. Change directory into the Noir project by running:
+3. Change directory into the Noir project and checkout the v0.3.2 release by running:
 
    ```bash
-   cd noir
+   cd noir && git checkout tags/v0.3.2
    ```
+
+Note that you can install the latest version by building the project directly from the `master`
+branch, but this may not work as expected or may include undocumented features since it is not an
+official release.
 
 There are then two approaches to proceed, differing in how the proving backend is installed:
 
@@ -175,26 +180,11 @@ TBC
 
 #### Verify Installation
 
-6. Check if the installation was successful by running `nargo --help`:
+6. Check if the installation was successful by running `nargo --version`:
 
    ```
-   $ nargo --help
-   
-   Noir's package manager
-
-   Usage: nargo <COMMAND>
-
-   Commands:
-      check             Checks the constraint system for errors
-      codegen-verifier  Generates a Solidity verifier smart contract for the program
-      compile           Compile the program and its secret execution trace into ACIR format
-      new               Create a new binary project
-      execute           Executes a circuit to calculate its return value
-      prove             Create proof for this program. The proof is returned as a hex encoded string
-      verify            Given a proof and a program, verify whether the proof is valid
-      test              Run the tests for this program
-      gates             Counts the occurrences of different gates in circuit
-      help              Print this message or the help of the given subcommand(s)
+   $ nargo --version
+   nargo 0.3.2 (git version hash: 29b1f7df4d563849a62e64c533cb62932188135b, is dirty: false)
    ```
 
 [git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git


### PR DESCRIPTION
- Copy of https://github.com/noir-lang/book/pull/88
  - Temporary patch until https://github.com/noir-lang/book/pull/90 out of draft
- Minor edit: Use `nargo --version` instead of `nargo --help` for installation check