### PR TITLE
Removing unecessary algolia optional params

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,26 +128,6 @@ const config = {
         apiKey: '8cdbbd8b0b98caab7765766267b1cb23',
 
         indexName: 'noir-lang',
-
-        // Optional: see doc section below
-        contextualSearch: true,
-
-        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-        externalUrlRegex: 'external\\.com|domain\\.com',
-
-        // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-        replaceSearchResultPathname: {
-          from: '/docs/', // or as RegExp: /\/docs\//
-          to: '/',
-        },
-
-        // Optional: Algolia search parameters
-        searchParameters: {},
-
-        // Optional: path for search page that enabled by default (`false` to disable it)
-        searchPagePath: 'search',
-
-        //... other Algolia params
       },
     }),
 };


### PR DESCRIPTION
From the docs, I figure these meant for complex documentation websites using several sources/domains, which isn't our case here