### PR TITLE
Fix newline in bashrc on install instructions

### DIFF
--- a/docs/getting_started/nargo/00_nargo_installation.md
+++ b/docs/getting_started/nargo/00_nargo_installation.md
@@ -77,7 +77,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 mkdir -p $HOME/.nargo/bin && \
 curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-x86_64-unknown-linux-gnu.tar.gz && \
 tar -xvf $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.nargo/bin/ && \
-echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
+echo -e '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
 source ~/.bashrc
 ```
 

--- a/versioned_docs/version-0.3.2/getting_started/nargo/00_nargo_installation.md
+++ b/versioned_docs/version-0.3.2/getting_started/nargo/00_nargo_installation.md
@@ -77,7 +77,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 mkdir -p $HOME/.nargo/bin && \
 curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.3.2/nargo-x86_64-unknown-linux-gnu.tar.gz && \
 tar -xvf $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.nargo/bin/ && \
-echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
+echo -e '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc && \
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
Running `echo '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc` in linux results in the actual string `\n` written to bashrc. The `-e` flag is needed so it's actually understood as a newline.