### PR TITLE
Delete Extra `$` in Link to PR

### DIFF
--- a/.github/MIGRATED_ISSUE.md
+++ b/.github/MIGRATED_ISSUE.md
@@ -4,4 +4,4 @@ labels: "migrated"
 # assignees: signorecello, critesjosh
 ---
 
-Document PR [#{{ env.PR }}](https://github.com/noir-lang/noir/pull/${{ env.PR }}) on the Noir repository.
+Document PR [#{{ env.PR }}](https://github.com/noir-lang/noir/pull/{{ env.PR }}) on the Noir repository.


### PR DESCRIPTION
Links in auto-created issues to `migrated` PRs are formatted with an extra `$`, which makes the links unaccessible.

Example: https://github.com/noir-lang/docs/issues/126