### PR TITLE
Update struct serialization to match noir-lang/noir#1166

### DIFF
--- a/docs/nargo/03_solidity_verifier.md
+++ b/docs/nargo/03_solidity_verifier.md
@@ -94,4 +94,4 @@ fn main(x: pub Field, nested: pub Nested, y: pub Field) {
 }
 ```
 
-Structs will be flattened so that the array of inputs is 1-dimensional array. The order of these inputs would be flattened to: `[x, nested.is_true, nested.t1.val1, nested.t1.val2, y]`
+Structs will be flattened so that the array of inputs is 1-dimensional array. The order of these inputs would be flattened to: `[x, nested.t1.val1, nested.t1.val2, nested.is_true, y]`


### PR DESCRIPTION
As of https://github.com/noir-lang/noir/pull/1166 structs are serialized in the same order as their fields are defined in Noir. I've then removed the alphabetical ordering we were performing here.