### PR TITLE
chore: Add option to install via nix

### DIFF
--- a/docs/getting_started/00_nargo_installation.md
+++ b/docs/getting_started/00_nargo_installation.md
@@ -152,7 +152,31 @@ Commands:
    help              Print this message or the help of the given subcommand(s)
 ```
 
-### Option 3: Compile from Source
+### Option 3: Install via Nix
+
+Due to the large number of native dependencies, Noir projects can be installed via [Nix](https://nixos.org/).
+
+#### Installing Nix
+
+For the best experience, please follow these instructions to setup Nix:
+
+1. Install Nix following [their guide](https://nixos.org/download.html) for your operating system.
+2. Create the file `~/.config/nix/nix.conf` with the contents:
+
+```ini
+experimental-features = nix-command
+extra-experimental-features = flakes
+```
+
+#### Install Nargo into your Nix profile
+
+1. Use `nix profile` to install Nargo
+
+```sh
+nix profile install github:noir-lang/noir
+```
+
+### Option 4: Compile from Source
 
 Due to the large number of native dependencies, Noir projects uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience.
 

--- a/versioned_docs/version-0.5.1/getting_started/00_nargo_installation.md
+++ b/versioned_docs/version-0.5.1/getting_started/00_nargo_installation.md
@@ -152,7 +152,31 @@ Commands:
    help              Print this message or the help of the given subcommand(s)
 ```
 
-### Option 3: Compile from Source
+### Option 3: Install via Nix
+
+Due to the large number of native dependencies, Nargo can be installed via [Nix](https://nixos.org/).
+
+#### Installing Nix
+
+For the best experience, please follow these instructions to setup Nix:
+
+1. Install Nix following [their guide](https://nixos.org/download.html) for your operating system.
+2. Create the file `~/.config/nix/nix.conf` with the contents:
+
+```ini
+experimental-features = nix-command
+extra-experimental-features = flakes
+```
+
+#### Install Nargo into your Nix profile
+
+1. Use `nix profile` to install Nargo
+
+```sh
+nix profile install github:noir-lang/noir/v0.5.1
+```
+
+### Option 4: Compile from Source
 
 Due to the large number of native dependencies, Noir projects uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience.
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/1197<!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This adds another option to install nargo via nix. In researching https://github.com/noir-lang/noir/issues/1197, I figured out the command to run to install nargo in a nix profile.

I updated the dev docs (using master) and the 0.5.1 docs (using the version tag).

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
