### PR TITLE
Resolve broken link in 'Black Box Function' template.

### DIFF
--- a/versioned_docs/version-0.5.1/standard_library/cryptographic_primitives/common/_blackbox.mdx
+++ b/versioned_docs/version-0.5.1/standard_library/cryptographic_primitives/common/_blackbox.mdx
@@ -1,5 +1,5 @@
 :::info
 
-This is a black box function. Read [this section](../../language_concepts/functions#black-box-functions) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](../../black_box_fns.md) to learn more about black box functions in Noir.
 
 :::


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description
I have made a minor change to resolve a file path used for several links in the docs @ version 5.1.

## Problem\*
A broken link in a template that is used in several places through the documentation.
This PR corrosponds with the Issue found [here](https://github.com/noir-lang/docs/issues/172).

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->
No major changes. Link simply points to appropriate content. Content seems to have been moved through the versions. 


### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```
Black box functions link pointed to regular functions. 
```

After:

```
Black box functions link points to specific content.
```

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
