### PR TITLE
chore(prettier): Revert `proseWrap` to Default Value

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,5 @@
     "arrowParens": "avoid",
     "singleQuote": true,
     "trailingComma": "all",
-    "printWidth": 100,
-    "proseWrap": "always"
+    "printWidth": 100
 }


### PR DESCRIPTION
# Description

## Problem\*

With the current Prettier settings, sentences exceeding 100 characters in the docs are always wrapped.

This could cause unintentional auto-formatting changes on PRs. 

## Summary\*

This PR deletes the custom setting of always prose wrapping, which reverts the setting to its default value `preserve` (i.e. respects and leaves authors' manual line breaks / lack of line breaks untouched).

Learn more about the setting here: [Prettier Docs](https://prettier.io/docs/en/options.html#prose-wrap)

Try the option out here: [Prettier Playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAZCAnOBbABASwAcBnAVzwBMIAbTXY-GXAQ2zhgBpdIpi4x4MUhhYUi+YmHxQA5rjjVGAOlwBJKLgCOpVrkUAjOBghdCAC2ZYYGZrij8Wi7brilTFqzZZMjEYkoAdKABFUgltOFwxXWZYOC5sGkViejgKOwlqO2guCmZCfH1SFLEBcj04CBUAQQQ4WNwAN0t8YtwIMQhcUiZ4bEI6aXgMCnJAqCCAZWLCBDFiPm5hMhTCYTaO-BN5GXYo-MK2xoVGXDXqRulLJsZmOCUQDhAIQhgt3mRQS2MAdwAFSwIYjIEDMag-ZgAT2BT30NjAAGt2JNWHBUNI4MgAGZgviw+FImCTQjMKSyZDWUjxEA4QwUChpVCxGQ6XYAMUw2GYMDe5JQzB6EEeIDMMGw1AA6mZGHBiCSwHBJkDGPhLjBISCwAthdI+BgYH8bDIudjcdSAFbEAAek2kMmocFCEHgpuoeJAJIwepBXIwCKoPygwsIGCGEvwFBgZmQAA4AAxPEN+OASmyEEEh2VGY7C7TOuCGl7A-nEAC09jSaWFWG0+CwhuYxuYrvdfGw+ApGCpTwYsgd1R5oaK8D+RnR9hb1N79sdpHzk6eMGY+nDkejSAATIubPhFLIAMIQbAmlCygCswuKcAAKsvizi3dTGlT1AzYJMwKHXtUoBRJuqHUnABfICgA)
You can toggle between the different option values to observe their effect under "Common" --> "--prose-wrap" in the options sidebar.

## Alternatives Considered

Update all doc pages according to the wrapping rule and fully enforce it as the default.

Can be unintuitive / quirky to some.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
