### PR TITLE
chore: Update VS Code Extension Link

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,5 @@
     "arrowParens": "avoid",
     "singleQuote": true,
     "trailingComma": "all",
-    "printWidth": 100,
-    "proseWrap": "always"
+    "printWidth": 100
 }

--- a/docs/getting_started/00_nargo_installation.md
+++ b/docs/getting_started/00_nargo_installation.md
@@ -211,6 +211,7 @@ Now that your environment is set up, you can get to work on the project.
 ```sh
 git clone git@github.com:noir-lang/noir
 ```
+
 > Replacing `noir` with whichever repository you want to work on.
 
 2. Navigate to the directory:
@@ -218,9 +219,10 @@ git clone git@github.com:noir-lang/noir
 ```sh
 cd noir
 ```
+
 > Replacing `noir` with whichever repository you cloned.
 
-3. You should see a __direnv error__ because projects aren't allowed by default. Make sure you've reviewed and trust our `.envrc` file, then you need to run:
+3. You should see a **direnv error** because projects aren't allowed by default. Make sure you've reviewed and trust our `.envrc` file, then you need to run:
 
 ```sh
 direnv allow
@@ -254,8 +256,7 @@ Advanced: If you aren't using direnv nor launching your editor within the subshe
 
 [git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [rust]: https://www.rust-lang.org/tools/install
-[noir vs code extension]:
-  https://marketplace.visualstudio.com/items?itemName=noir-lang.noir-programming-language-syntax-highlighter
+[noir vs code extension]: https://marketplace.visualstudio.com/items?itemName=noir-lang.noir-programming-language-syntax-highlighter
 [homebrew]: https://brew.sh/
 [cmake]: https://cmake.org/install/
 [llvm]: https://llvm.org/docs/GettingStarted.html

--- a/docs/getting_started/00_nargo_installation.md
+++ b/docs/getting_started/00_nargo_installation.md
@@ -256,7 +256,7 @@ Advanced: If you aren't using direnv nor launching your editor within the subshe
 
 [git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [rust]: https://www.rust-lang.org/tools/install
-[noir vs code extension]: https://marketplace.visualstudio.com/items?itemName=noir-lang.noir-programming-language-syntax-highlighter
+[noir vs code extension]: https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir
 [homebrew]: https://brew.sh/
 [cmake]: https://cmake.org/install/
 [llvm]: https://llvm.org/docs/GettingStarted.html


### PR DESCRIPTION
# Description

## Summary\*

This PR updates the docs to point readers to the new [Noir Language Support VS Code Extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir), which exposes Language Server Protocol features in the IDE when paired with ≥v0.7.1 Nargo installed.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
