### PR TITLE
Adding run test codelens (don't merge until vscode 0.0.4 is out)

### DIFF
--- a/docs/getting_started/03_language_server.md
+++ b/docs/getting_started/03_language_server.md
@@ -23,6 +23,8 @@ The Client component is usually an editor plugin that launches the Server. It co
 
 Currently, Noir provides a Language Client for Visual Studio Code via the [vscode-noir](https://github.com/noir-lang/vscode-noir) extension. You can install it via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir).
 
+Noir also provides some useful codelenses you can use through the LSP, such as `Run Test`.
+
 ### Configuration
 
 * __Noir: Enable LSP__ - If checked, the extension will launch the Language Server via `nargo lsp` and communicate with it.


### PR DESCRIPTION
closes #211 

We shouldn't merge this until the 0.0.4 release of `vscode-noir` is out