### PR TITLE
Jc/GitHub code renderer

### DIFF
--- a/docs/examples/merkle-proof.mdx
+++ b/docs/examples/merkle-proof.mdx
@@ -7,9 +7,6 @@ keywords:
   [merkle proof, merkle membership proof, Noir, rust, hash function, Pedersen, sha256, merkle tree]
 ---
 
-import GitHubCode from '../../src/components/GithubCode';
-import { Highlight, themes } from 'prism-react-renderer';
-
 Let's walk through an example of a merkle membership proof in Noir that proves that a given leaf is
 in a merkle tree.
 
@@ -48,12 +45,4 @@ An example, the merkle membership proof, only requires a hash function that has 
 resistance, hence a hash function like Pedersen is allowed, which in most cases is more efficient
 than the even more conservative sha256.
 
-[view an example on the starter repo](https://github.com/noir-lang/noir-examples/blob/3ea09545cabfa464124ec2f3ea8e60c608abe6df/stealthdrop/circuits/src/main.nr#L20)
-
-<GitHubCode
-  owner="noir-lang"
-  repo="noir-examples"
-  branch="master"
-  filePath="stealthdrop/circuits/src/main.nr"
-  language="rust"
-/>
+[View an example on the starter repo](https://github.com/noir-lang/noir-examples/blob/3ea09545cabfa464124ec2f3ea8e60c608abe6df/stealthdrop/circuits/src/main.nr#L20)

--- a/docs/examples/merkle-proof.mdx
+++ b/docs/examples/merkle-proof.mdx
@@ -55,4 +55,5 @@ than the even more conservative sha256.
   repo="noir-examples"
   branch="master"
   filePath="stealthdrop/circuits/src/main.nr"
+  language="rust"
 />

--- a/docs/examples/merkle-proof.mdx
+++ b/docs/examples/merkle-proof.mdx
@@ -7,6 +7,9 @@ keywords:
   [merkle proof, merkle membership proof, Noir, rust, hash function, Pedersen, sha256, merkle tree]
 ---
 
+import GitHubCode from '../../src/components/GithubCode';
+import { Highlight, themes } from 'prism-react-renderer';
+
 Let's walk through an example of a merkle membership proof in Noir that proves that a given leaf is
 in a merkle tree.
 
@@ -46,3 +49,10 @@ resistance, hence a hash function like Pedersen is allowed, which in most cases 
 than the even more conservative sha256.
 
 [view an example on the starter repo](https://github.com/noir-lang/noir-examples/blob/3ea09545cabfa464124ec2f3ea8e60c608abe6df/stealthdrop/circuits/src/main.nr#L20)
+
+<GitHubCode
+  owner="noir-lang"
+  repo="noir-examples"
+  branch="master"
+  filePath="stealthdrop/circuits/src/main.nr"
+/>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/preset-classic": "^2.4.0",
     "@easyops-cn/docusaurus-search-local": "^0.35.0",
     "@mdx-js/react": "^1.6.22",
+    "axios": "^1.4.0",
     "clsx": "^1.2.1",
     "hast-util-is-element": "^1.1.0",
     "prism-react-renderer": "^1.3.5",

--- a/src/components/GithubCode/index.js
+++ b/src/components/GithubCode/index.js
@@ -4,7 +4,7 @@ import Highlight, { defaultProps } from "prism-react-renderer";
 import github from 'prism-react-renderer/themes/github';
 //import vsDark from 'prism-react-renderer/themes/vsDark';
 
-const GitHubCode = ({ owner, repo, branch = 'master', filePath, startLine = 1, endLine = Infinity }) => {
+const GitHubCode = ({ owner, repo, branch = 'master', filePath, language, startLine = 1, endLine = Infinity }) => {
     const [code, setCode] = useState('');
 
     useEffect(() => {
@@ -32,7 +32,7 @@ const GitHubCode = ({ owner, repo, branch = 'master', filePath, startLine = 1, e
             {...defaultProps}
             code={code}
             theme={github}
-            language="rust"
+            language={language}
         >
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre style={style}>

--- a/src/components/GithubCode/index.js
+++ b/src/components/GithubCode/index.js
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import Highlight, { defaultProps } from "prism-react-renderer";
+import github from 'prism-react-renderer/themes/github';
+//import vsDark from 'prism-react-renderer/themes/vsDark';
+
+const GitHubCode = ({ owner, repo, branch = 'master', filePath, startLine = 1, endLine = Infinity }) => {
+    const [code, setCode] = useState('');
+
+    useEffect(() => {
+        const fetchCode = async () => {
+            const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`
+            try {
+                const response = await axios.get(url);
+                const content = response.data.content;
+                const decodedContent = atob(content); // Decode Base64 content
+
+                const lines = decodedContent.split('\n');
+                const desiredLines = lines.slice(startLine - 1, endLine).join('\n');
+
+                setCode(desiredLines);
+            } catch (error) {
+                console.error('Failed to fetch GitHub code:', error, url);
+            }
+        };
+
+        fetchCode();
+    }, [owner, repo, branch, filePath, startLine, endLine]);
+
+    const highlighted = (
+        <Highlight
+            {...defaultProps}
+            code={code}
+            theme={github}
+            language="rust"
+        >
+            {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre style={style}>
+                    {tokens.map((line, i) => (
+                        <div key={i} {...getLineProps({ line })}>
+                            {/* uncomment for line numbers */}
+                            {/* <span>{i + 1}</span> */}
+                            {line.map((token, key) => (
+                                <span key={key} {...getTokenProps({ token })} />
+                            ))}
+                        </div>
+                    ))}
+                </pre>
+            )}
+        </Highlight>
+    )
+
+    return highlighted;
+};
+
+export default GitHubCode;

--- a/src/components/GithubCode/index.js
+++ b/src/components/GithubCode/index.js
@@ -6,6 +6,7 @@ import github from 'prism-react-renderer/themes/github';
 
 const GitHubCode = ({ owner, repo, branch = 'master', filePath, language, startLine = 1, endLine = Infinity }) => {
     const [code, setCode] = useState('');
+    const [response, setResponse] = useState('');
 
     useEffect(() => {
         const fetchCode = async () => {
@@ -16,18 +17,19 @@ const GitHubCode = ({ owner, repo, branch = 'master', filePath, language, startL
                 const decodedContent = atob(content); // Decode Base64 content
 
                 const lines = decodedContent.split('\n');
-                const desiredLines = lines.slice(startLine - 1, endLine).join('\n');
+                const desiredLines = lines.slice(startLine - 1, endLine).join('\n').trimEnd();
 
+                setResponse(response);
                 setCode(desiredLines);
             } catch (error) {
-                console.error('Failed to fetch GitHub code:', error, url);
+                console.error('Failed to fetch GitHub code:', error);
             }
         };
 
         fetchCode();
     }, [owner, repo, branch, filePath, startLine, endLine]);
 
-    const highlighted = (
+    const highlightedCode = (
         <Highlight
             {...defaultProps}
             code={code}
@@ -35,22 +37,27 @@ const GitHubCode = ({ owner, repo, branch = 'master', filePath, language, startL
             language={language}
         >
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                <pre style={style}>
-                    {tokens.map((line, i) => (
-                        <div key={i} {...getLineProps({ line })}>
-                            {/* uncomment for line numbers */}
-                            {/* <span>{i + 1}</span> */}
-                            {line.map((token, key) => (
-                                <span key={key} {...getTokenProps({ token })} />
-                            ))}
-                        </div>
-                    ))}
-                </pre>
+                <div>
+                    <pre style={style}>
+                        {tokens.map((line, i) => (
+                            <div key={i} {...getLineProps({ line })}>
+                                {/* uncomment for line numbers */}
+                                {/* <span>{i + 1}</span> */}
+                                {line.map((token, key) => (
+                                    <span key={key} {...getTokenProps({ token })} />
+                                ))}
+                            </div>
+                        ))}
+                    </pre>
+                    {
+                        response.data?.html_url ? <a href={response.data.html_url} target="_blank">Link to source code.</a> : ''
+                    }
+                </div>
             )}
         </Highlight>
     )
 
-    return highlighted;
+    return highlightedCode;
 };
 
 export default GitHubCode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,6 +2837,11 @@ asap@~2.0.3:
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
@@ -2860,6 +2865,15 @@ axios@^0.25.0:
   integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
     follow-redirects "^1.14.7"
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-loader@^8.2.5:
   version "8.3.0"
@@ -3295,6 +3309,13 @@ combine-promises@^1.1.0:
   resolved "https://registry.npmjs.org/combine-promises/-/combine-promises-1.1.0.tgz"
   integrity sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz"
@@ -3699,6 +3720,11 @@ del@^6.1.1:
     p-map "^4.0.0"
     rimraf "^3.0.2"
     slash "^3.0.0"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0:
   version "2.0.0"
@@ -4225,7 +4251,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -4248,6 +4274,15 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4592,6 +4627,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^11.8.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.8.0.tgz#966518ea83257bae2e7c9a48596231856555bb65"
+  integrity sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==
 
 history@^4.9.0:
   version "4.10.1"
@@ -5457,7 +5497,7 @@ mime-types@2.1.18, mime-types@~2.1.17:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -6269,6 +6309,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Adds a docs component so that you can import and render code directly from github source files.

- You can specify specific line numbers to render, or omit to include the whole file. 
- You can specify what language to use for syntax highlighting.
- You can specify a specific branch to render from.


h/t to @iAmMichaelConnor for doing most of this
