### PR TITLE
feat: fix snippets

### DIFF
--- a/versioned_docs/version-0.3.2/standard_library/array_methods.md
+++ b/versioned_docs/version-0.3.2/standard_library/array_methods.md
@@ -22,7 +22,7 @@ example
 
 ```rust
 fn main() {
-    let array = [42, 42]
+    let array = [42, 42];
     constrain array.len() == 2;
 }
 ```

--- a/versioned_docs/version-0.3.2/standard_library/array_methods.md
+++ b/versioned_docs/version-0.3.2/standard_library/array_methods.md
@@ -23,7 +23,7 @@ example
 ```rust
 fn main() {
     let array = [42, 42]
-    constrain arr.len() == 2;
+    constrain array.len() == 2;
 }
 ```
 

--- a/versioned_docs/version-0.4.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.4.1/standard_library/array_methods.md
@@ -22,7 +22,7 @@ example
 
 ```rust
 fn main() {
-    let array = [42, 42]
+    let array = [42, 42];
     constrain array.len() == 2;
 }
 ```

--- a/versioned_docs/version-0.4.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.4.1/standard_library/array_methods.md
@@ -81,7 +81,7 @@ example
 
 ```rust
 let a = [1, 2, 3];
-let b = f.map(|a| a * 2) // b is now [2, 4, 6]
+let b = f.map(|a| a * 2); // b is now [2, 4, 6]
 ```
 
 ## fold

--- a/versioned_docs/version-0.4.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.4.1/standard_library/array_methods.md
@@ -23,7 +23,7 @@ example
 ```rust
 fn main() {
     let array = [42, 42]
-    constrain arr.len() == 2;
+    constrain array.len() == 2;
 }
 ```
 
@@ -82,7 +82,7 @@ example
 ```rust
 let a = [1, 2, 3];
 let b = f.map(|a| a * 2) // b is now [2, 4, 6]
-``` 
+```
 
 ## fold
 

--- a/versioned_docs/version-0.5.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.5.1/standard_library/array_methods.md
@@ -22,7 +22,7 @@ example
 
 ```rust
 fn main() {
-    let array = [42, 42]
+    let array = [42, 42];
     constrain array.len() == 2;
 }
 ```

--- a/versioned_docs/version-0.5.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.5.1/standard_library/array_methods.md
@@ -81,7 +81,7 @@ example
 
 ```rust
 let a = [1, 2, 3];
-let b = f.map(|a| a * 2) // b is now [2, 4, 6]
+let b = f.map(|a| a * 2); // b is now [2, 4, 6]
 ```
 
 ## fold

--- a/versioned_docs/version-0.5.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.5.1/standard_library/array_methods.md
@@ -23,7 +23,7 @@ example
 ```rust
 fn main() {
     let array = [42, 42]
-    constrain arr.len() == 2;
+    constrain array.len() == 2;
 }
 ```
 
@@ -82,7 +82,7 @@ example
 ```rust
 let a = [1, 2, 3];
 let b = f.map(|a| a * 2) // b is now [2, 4, 6]
-``` 
+```
 
 ## fold
 

--- a/versioned_docs/version-0.6.0/standard_library/array_methods.md
+++ b/versioned_docs/version-0.6.0/standard_library/array_methods.md
@@ -22,7 +22,7 @@ example
 
 ```rust
 fn main() {
-    let array = [42, 42]
+    let array = [42, 42];
     constrain array.len() == 2;
 }
 ```

--- a/versioned_docs/version-0.6.0/standard_library/array_methods.md
+++ b/versioned_docs/version-0.6.0/standard_library/array_methods.md
@@ -23,7 +23,7 @@ example
 ```rust
 fn main() {
     let array = [42, 42]
-    constrain arr.len() == 2;
+    constrain array.len() == 2;
 }
 ```
 
@@ -82,7 +82,7 @@ example
 ```rust
 let a = [1, 2, 3];
 let b = a.map(|a| a * 2) // b is now [2, 4, 6]
-``` 
+```
 
 ## fold
 

--- a/versioned_docs/version-0.7.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.7.1/standard_library/array_methods.md
@@ -42,7 +42,7 @@ example
 
 ```rust
 fn main() {
-    let arr = [42, 32]
+    let arr = [42, 32];
     let sorted = arr.sort();
     assert(sorted == [32, 42]);
 }
@@ -81,7 +81,7 @@ example
 
 ```rust
 let a = [1, 2, 3];
-let b = a.map(|a| a * 2) // b is now [2, 4, 6]
+let b = a.map(|a| a * 2); // b is now [2, 4, 6]
 ```
 
 ## fold
@@ -112,7 +112,7 @@ example:
 ```rust
 
 fn main() {
-    let arr = [2,2,2,2,2]
+    let arr = [2, 2, 2, 2, 2];
     let folded = arr.fold(0, |a, b| a + b);
     assert(folded == 10);
 }
@@ -131,7 +131,7 @@ example:
 
 ```rust
 fn main() {
-    let arr = [2,2,2,2,2]
+    let arr = [2, 2, 2, 2, 2];
     let reduced = arr.reduce(|a, b| a + b);
     assert(reduced == 10);
 }
@@ -149,7 +149,7 @@ example:
 
 ```rust
 fn main() {
-    let arr = [2,2,2,2,2]
+    let arr = [2, 2, 2, 2, 2];
     let all = arr.all(|a| a == 2);
     assert(all);
 }
@@ -167,7 +167,7 @@ example:
 
 ```rust
 fn main() {
-    let arr = [2,2,2,2,5]
+    let arr = [2, 2, 2, 2, 5];
     let any = arr.any(|a| a == 5);
     assert(any);
 }

--- a/versioned_docs/version-0.7.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.7.1/standard_library/array_methods.md
@@ -23,7 +23,7 @@ example
 ```rust
 fn main() {
     let array = [42, 42]
-    assert(arr.len() == 2);
+    assert(array.len() == 2);
 }
 ```
 
@@ -82,7 +82,7 @@ example
 ```rust
 let a = [1, 2, 3];
 let b = a.map(|a| a * 2) // b is now [2, 4, 6]
-``` 
+```
 
 ## fold
 

--- a/versioned_docs/version-0.7.1/standard_library/array_methods.md
+++ b/versioned_docs/version-0.7.1/standard_library/array_methods.md
@@ -22,7 +22,7 @@ example
 
 ```rust
 fn main() {
-    let array = [42, 42]
+    let array = [42, 42];
     assert(array.len() == 2);
 }
 ```


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Some snippets from the docs do not work when copying/pasting them due to incorrect variable names/missing semicolons

Resolves https://github.com/noir-lang/docs/issues/312

## Summary\*

Fixes some snippets in the docs

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
