### PR TITLE
chore: remove `--show-output`

### DIFF
--- a/docs/nargo/01_commands.md
+++ b/docs/nargo/01_commands.md
@@ -24,7 +24,6 @@ keywords:
 Options:
   -s, --show-ssa        Emit debug information for the intermediate SSA IR
   -d, --deny-warnings   Quit execution when warnings are emitted
-      --show-output     Display output of `println` statements during tests
   -h, --help            Print help
 ```
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

remove `--show-output` as an option cus it is now enabled by default https://github.com/noir-lang/noir/pull/2019

(forgot to do this couple of days ago..

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
