### PR TITLE
Changed deprecated `constrain` by `assert` in project breakdown.

### DIFF
--- a/docs/getting_started/02_breakdown.md
+++ b/docs/getting_started/02_breakdown.md
@@ -69,7 +69,7 @@ y = "2"
 When the command `nargo prove my_proof` is executed, two processes happen:
 
 1. Noir creates a proof that `x` which holds the value of `1` and `y` which holds the value of `2`
-   is not equal. This not equal constraint is due to the line `constrain x != y`.
+   is not equal. This not equal constraint is due to the line `assert(x != y)`.
 
 2. Noir creates and stores the proof of this statement in the _proofs_ directory and names the proof
    file _my_proof_. Opening this file will display the proof in hex format.

--- a/versioned_docs/version-0.7.1/getting_started/02_breakdown.md
+++ b/versioned_docs/version-0.7.1/getting_started/02_breakdown.md
@@ -50,7 +50,7 @@ verifying the proof.
 
 The prover supplies the values for `x` and `y` in the _Prover.toml_ file.
 
-As for the program body, `constrain` ensures the satisfaction of the condition (e.g. `x != y`) is
+As for the program body, `assert` ensures the satisfaction of the condition (e.g. `x != y`) is
 constrained by the proof of the execution of said program (i.e. if the condition was not met, the
 verifier would reject the proof as an invalid proof).
 
@@ -69,7 +69,7 @@ y = "2"
 When the command `nargo prove my_proof` is executed, two processes happen:
 
 1. Noir creates a proof that `x` which holds the value of `1` and `y` which holds the value of `2`
-   is not equal. This not equal constraint is due to the line `constrain x != y`.
+   is not equal. This not equal constraint is due to the line `assert(x != y)`.
 
 2. Noir creates and stores the proof of this statement in the _proofs_ directory and names the proof
    file _my_proof_. Opening this file will display the proof in hex format.


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Summary\

Changes deprecated `constrain` by `assert` in the project breakdown page.

# PR Checklist\

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
