### PR TITLE
docs: grammatical fix

### DIFF
--- a/docs/language_concepts/00_data_types.md
+++ b/docs/language_concepts/00_data_types.md
@@ -212,7 +212,7 @@ You can create arrays of primitive types or structs. There is not yet support fo
 
 A slice is a dynamically-sized view into a sequence of elements. They can be resized at runtime, but because they don't own the data, they cannot be returned from a circuit. You can treat slices as arrays without a constrained size.
 
-Slices are part of the [noir standard library](../standard_library/slice_methods) so you need to import the respetive module in order to work with it. For example:
+Slices are part of the [noir standard library](../standard_library/slice_methods) so you need to import the respective module in order to work with it. For example:
 
 ```rust
 use dep::std::slice;

--- a/versioned_docs/version-0.9.0/language_concepts/00_data_types.md
+++ b/versioned_docs/version-0.9.0/language_concepts/00_data_types.md
@@ -212,7 +212,7 @@ You can create arrays of primitive types or structs. There is not yet support fo
 
 A slice is a dynamically-sized view into a sequence of elements. They can be resized at runtime, but because they don't own the data, they cannot be returned from a circuit. You can treat slices as arrays without a constrained size.
 
-Slices are part of the [noir standard library](../standard_library/slice_methods) so you need to import the respetive module in order to work with it. For example:
+Slices are part of the [noir standard library](../standard_library/slice_methods) so you need to import the respective module in order to work with it. For example:
 
 ```rust
 use dep::std::slice;


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description
Correcting the spelling of *respective* in two files with path `docs/language_concepts/00_data_types.md` and `versioned_docs/version-0.9.0/language_concepts/00_data_types.md`

## Problem\*
Spelling of respective was respetive.
<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->


## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

Fixes the spelling of respective from respetive

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [✅ ] I have tested the changes locally.
- [✅ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
