### PR TITLE
Consentsam patch 1

### DIFF
--- a/docs/language_concepts/07_mutability.md
+++ b/docs/language_concepts/07_mutability.md
@@ -79,7 +79,7 @@ fn main(runtime_var: Field) -> pub Field {
 }
 ```
 
-As `runtime_var`` is a argument to the circuit it cannot be known at compile time and so assigning it to a comptime variable should fail. A circuit's arguments is the only way in which non-comptime variables can enter the circuit (excluding [brillig](./unconstrained) foreign calls).
+As `runtime_var` is a argument to the circuit it cannot be known at compile time and so assigning it to a comptime variable should fail. A circuit's arguments is the only way in which non-comptime variables can enter the circuit (excluding [brillig](./unconstrained) foreign calls).
 
 ## Globals
 

--- a/docs/language_concepts/09_distinct.md
+++ b/docs/language_concepts/09_distinct.md
@@ -8,7 +8,7 @@ that the witnesses being returned as public inputs are all unique.
 The `distinct` keyword is only used for return values on program entry points (usually the `main()`
 function).
 
-When using `disctinct` and `pub` simultaneously, `distinct` comes first. See the example below.
+When using `distinct` and `pub` simultaneously, `distinct` comes first. See the example below.
 
 You can read more about the problem this solves
 [here](https://github.com/noir-lang/noir/issues/1183).

--- a/docs/standard_library/cryptographic_primitives/04_ec_primitives.md
+++ b/docs/standard_library/cryptographic_primitives/04_ec_primitives.md
@@ -30,7 +30,7 @@ mixed coordinate representation is employed).
 ### Points
 
 (`std::ec::{tecurve,montcurve,swcurve}::{affine,curvegroup}::Point`), i.e. points lying on the
-elliptic curve. For a curve configuration `c` and a point `p`, it may be checked checked that `p`
+elliptic curve. For a curve configuration `c` and a point `p`, it may be checked that `p`
 does indeed lie on `c` by calling `c.contains(p1)`.
 
 ## Methods

--- a/versioned_docs/version-0.9.0/language_concepts/07_mutability.md
+++ b/versioned_docs/version-0.9.0/language_concepts/07_mutability.md
@@ -79,7 +79,7 @@ fn main(runtime_var: Field) -> pub Field {
 }
 ```
 
-As `runtime_var`` is a argument to the circuit it cannot be known at compile time and so assigning it to a comptime variable should fail. A circuit's arguments is the only way in which non-comptime variables can enter the circuit (excluding [brillig](./unconstrained) foreign calls).
+As `runtime_var` is a argument to the circuit it cannot be known at compile time and so assigning it to a comptime variable should fail. A circuit's arguments is the only way in which non-comptime variables can enter the circuit (excluding [brillig](./unconstrained) foreign calls).
 
 ## Globals
 

--- a/versioned_docs/version-0.9.0/language_concepts/09_distinct.md
+++ b/versioned_docs/version-0.9.0/language_concepts/09_distinct.md
@@ -8,7 +8,7 @@ that the witnesses being returned as public inputs are all unique.
 The `distinct` keyword is only used for return values on program entry points (usually the `main()`
 function).
 
-When using `disctinct` and `pub` simultaneously, `distinct` comes first. See the example below.
+When using `distinct` and `pub` simultaneously, `distinct` comes first. See the example below.
 
 You can read more about the problem this solves
 [here](https://github.com/noir-lang/noir/issues/1183).

--- a/versioned_docs/version-0.9.0/standard_library/cryptographic_primitives/04_ec_primitives.md
+++ b/versioned_docs/version-0.9.0/standard_library/cryptographic_primitives/04_ec_primitives.md
@@ -30,7 +30,7 @@ mixed coordinate representation is employed).
 ### Points
 
 (`std::ec::{tecurve,montcurve,swcurve}::{affine,curvegroup}::Point`), i.e. points lying on the
-elliptic curve. For a curve configuration `c` and a point `p`, it may be checked checked that `p`
+elliptic curve. For a curve configuration `c` and a point `p`, it may be checked that `p`
 does indeed lie on `c` by calling `c.contains(p1)`.
 
 ## Methods


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description
The series of commits fixes very small grammatical or formatting issues in the Noir documentation

## Summary\*

<!-- Describe the changes in this PR. -->
- **Commit 805092d** - [format: fixes formatting by removing extra tilde](https://github.com/noir-lang/docs/commit/805092d18bb9b7a80a4a5bffcad9b95fe271dced)
- **Commit f77aeb4** - [docs: fixes spelling mistake of distinct from disctinct ](https://github.com/noir-lang/docs/commit/f77aeb426be622ca4bd35ba962196964c6f84c35)
- **Commit 3211f81** - [docs: removes double occurance of checked](https://github.com/noir-lang/docs/commit/3211f819102c362ab39fc03e433102452801b4b5)

<!-- Supplement code examples and highlight breaking changes, if applicable. -->
The series of commits fixes very small grammatical or formatting issues in the Noir documentation


## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [✅ ] I have tested the changes locally.
- [✅ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
