### PR TITLE
replace constrain with assert in 0.7+ versions

### DIFF
--- a/docs/language_concepts/00_data_types.md
+++ b/docs/language_concepts/00_data_types.md
@@ -133,7 +133,7 @@ fn main() {
 > **Note:** When returning a boolean value, it will show up as a value of 1 for `true` and 0 for
 > `false` in _Verifier.toml_.
 
-The boolean type is most commonly used in conditionals like `if` expressions and `constrain`
+The boolean type is most commonly used in conditionals like `if` expressions and `assert`
 statements. More about conditionals is covered in the [Control Flow](./control_flow) and
 [Assert Function](./assert) sections.
 

--- a/docs/language_concepts/03_ops.md
+++ b/docs/language_concepts/03_ops.md
@@ -72,12 +72,12 @@ let mut flag = 1;
 if (my_val > 6) | (my_val == 0) {
     flag = 0;
 }
-constrain flag == 1;
+assert(flag == 1);
 
 if (my_val != 10) & (my_val < 50) {
     flag = 0;
 }
-constrain flag == 0;
+assert(flag == 0);
 ```
 
 ### Shorthand operators

--- a/versioned_docs/version-0.7.1/language_concepts/00_data_types.md
+++ b/versioned_docs/version-0.7.1/language_concepts/00_data_types.md
@@ -133,7 +133,7 @@ fn main() {
 > **Note:** When returning a boolean value, it will show up as a value of 1 for `true` and 0 for
 > `false` in _Verifier.toml_.
 
-The boolean type is most commonly used in conditionals like `if` expressions and `constrain`
+The boolean type is most commonly used in conditionals like `if` expressions and `assert`
 statements. More about conditionals is covered in the [Control Flow](./control_flow) and
 [Assert Function](./assert) sections.
 

--- a/versioned_docs/version-0.7.1/language_concepts/03_ops.md
+++ b/versioned_docs/version-0.7.1/language_concepts/03_ops.md
@@ -72,12 +72,12 @@ let mut flag = 1;
 if (my_val > 6) | (my_val == 0) {
     flag = 0;
 }
-constrain flag == 1;
+assert(flag == 1);
 
 if (my_val != 10) & (my_val < 50) {
     flag = 0;
 }
-constrain flag == 0;
+assert(flag == 0);
 ```
 
 ### Shorthand operators

--- a/versioned_docs/version-0.9.0/language_concepts/00_data_types.md
+++ b/versioned_docs/version-0.9.0/language_concepts/00_data_types.md
@@ -133,7 +133,7 @@ fn main() {
 > **Note:** When returning a boolean value, it will show up as a value of 1 for `true` and 0 for
 > `false` in _Verifier.toml_.
 
-The boolean type is most commonly used in conditionals like `if` expressions and `constrain`
+The boolean type is most commonly used in conditionals like `if` expressions and `assert`
 statements. More about conditionals is covered in the [Control Flow](./control_flow) and
 [Assert Function](./assert) sections.
 

--- a/versioned_docs/version-0.9.0/language_concepts/03_ops.md
+++ b/versioned_docs/version-0.9.0/language_concepts/03_ops.md
@@ -72,12 +72,12 @@ let mut flag = 1;
 if (my_val > 6) | (my_val == 0) {
     flag = 0;
 }
-constrain flag == 1;
+assert(flag == 1);
 
 if (my_val != 10) & (my_val < 50) {
     flag = 0;
 }
-constrain flag == 0;
+assert(flag == 0);
 ```
 
 ### Shorthand operators


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*


There are a few places in the docs where the deprecated syntax for constraints is still used (`constrain foo;` instead of `assert(foo);`)

This PR replaces the remaining usages of `constrain` with `assert` for versions 0.7.1, 0.9 as well as dev.

I've left 0.6.0 docs intact, because they use `constrain` everywhere, even though by looking at the changelogs I believe 0.6.0 was the version that introduced the new syntax (https://github.com/noir-lang/noir/compare/v0.5.1...v0.6.0)

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
