### PR TITLE
refactor: fixes typo in Closures code

### DIFF
--- a/versioned_docs/version-0.10.5/language_concepts/08_lambdas.md
+++ b/versioned_docs/version-0.10.5/language_concepts/08_lambdas.md
@@ -33,7 +33,7 @@ Inside the body of a lambda, you can use variables defined in the enclosing func
 fn main() {
   let x = 100;
   let closure = || x + 150;
-  assert(closure() == 150);
+  assert(closure() == 250);
 }
 ```
 


### PR DESCRIPTION

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description
Based on the logic outlined in the [closures section](https://noir-lang.org/language_concepts/lambdas/#closures), the value would be 250 instead of 150 in the following code

```
fn main() {
  let x = 100;
  let closure = || x + 150;
  assert(closure() == 150);// RHS would be 250
}
```


This is because the variable `x` from the enclosing function is utilised and subsequently summed with 100, leading to a cumulative value of 250, which would be the return value of the closure.

# PR Checklist\*

- [✅ ] I have tested the changes locally.
- [✅ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
