### PR TITLE
Update workspace doc page

### DIFF
--- a/docs/modules_packages_crates/workspaces.md
+++ b/docs/modules_packages_crates/workspaces.md
@@ -34,6 +34,4 @@ default-member = "crates/a"
 
 `default-member` indicates which package various commands process by default.
 
-Libraries can be defined in a workspace. We just don't have a way to consume libraries from inside a workspace as external dependencies right now.
-
-Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
+Libraries can be defined in a workspace. Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

We can consume libs from inside a workspace as external dependencies now.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
